### PR TITLE
ci: add ruff and coverage

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,40 +1,42 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
-
-name: Python package
+name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
-  build:
-
+  test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
-
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    defaults:
+      run:
+        working-directory: llm-signature-framework-v0.2.2
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        pytest
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev]
+      - name: Ruff auto-fix
+        if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ruff-fix')
+        run: ruff --fix .
+      - name: Commit fixes
+        if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ruff-fix')
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: apply ruff fixes"
+      - name: Lint with Ruff
+        run: ruff check .
+      - name: Test with pytest
+        run: pytest --cov=src --cov-report=term --cov-fail-under=80


### PR DESCRIPTION
## Summary
- run ruff and pytest with coverage on Python 3.9–3.12
- allow optional label-triggered `ruff --fix` step

## Testing
- `ruff check .` *(fails: Multiple statements on one line, import sorting, etc.)*
- `pytest --cov=src --cov-report=term --cov-fail-under=80` *(fails: `pydantic.errors.PydanticUserError: 'regex' is removed. use 'pattern' instead`)*

------
https://chatgpt.com/codex/tasks/task_e_68a87e29a468832da810bc478b269c8a