### PR TITLE
chore: add coverage config and gitignore

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+source = src
+
+[report]
+fail_under = 80
+show_missing = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,52 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+.eggs/
+*.egg
+
+# Virtual environments
+.venv/
+venv/
+ENV/
+env/
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache/
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+*.lcov
+
+# pytest
+.pytest_cache/
+
+# Ruff
+.ruff_cache/
+
+# mypy
+.mypy_cache/
+
+# IDEs and editors
+.idea/
+.vscode/
+
+# macOS
+.DS_Store
+
+# Project artifacts
+llm-signature-framework-v0.2.2/.llm_state.json
+llm-signature-framework-v0.2.2/runs/


### PR DESCRIPTION
## Summary
- add root `.coveragerc` mirroring CI coverage settings
- add `.gitignore` for Python caches, coverage outputs, virtual envs, and project artifacts

## Testing
- `pytest --cov=src`


------
https://chatgpt.com/codex/tasks/task_e_68a888bf7968832d8198c09ff6c2bd33