### PR TITLE
Add unit and integration tests

### DIFF
--- a/llm-signature-framework-v0.2.2/tests/test_backends.py
+++ b/llm-signature-framework-v0.2.2/tests/test_backends.py
@@ -1,0 +1,16 @@
+import os
+from llm_signature_framework.backends import get_backend, set_backend, MockBackend
+
+
+def test_get_backend_default_and_override(monkeypatch):
+    set_backend(None)
+    monkeypatch.delenv("LLM_BACKEND", raising=False)
+    assert isinstance(get_backend(), MockBackend)
+
+    mock = MockBackend()
+    set_backend(mock)
+    assert get_backend() is mock
+
+    set_backend(None)
+    monkeypatch.setenv("LLM_BACKEND", "mock")
+    assert isinstance(get_backend(), MockBackend)

--- a/llm-signature-framework-v0.2.2/tests/test_cli.py
+++ b/llm-signature-framework-v0.2.2/tests/test_cli.py
@@ -1,0 +1,27 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from llm_signature_framework.templates import __version__
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = str(PROJECT_ROOT / "src")
+
+
+def run_cli(*args):
+    env = os.environ.copy()
+    env.update({"PYTHONPATH": SRC_PATH, "LLM_BACKEND": "mock"})
+    cmd = [sys.executable, "-m", "llm_signature_framework.cli", *args]
+    return subprocess.run(cmd, capture_output=True, text=True, env=env)
+
+
+def test_cli_print_version():
+    res = run_cli("--print-version")
+    assert res.stdout.strip() == __version__
+
+
+def test_cli_run_demo():
+    res = run_cli("run", "--name", "demo_loop_and_if", "--json", '{"things":["x"],"flag": true}')
+    assert "mock-reply" in res.stdout
+    assert res.returncode == 0

--- a/llm-signature-framework-v0.2.2/tests/test_templates.py
+++ b/llm-signature-framework-v0.2.2/tests/test_templates.py
@@ -1,0 +1,19 @@
+import pytest
+from llm_signature_framework.templates import _MiniTemplate
+
+
+def test_minitemplate_loop_and_if():
+    tmpl_text = (
+        "Hi {name}!"
+        "{% for n in nums %}[{n}]{% endfor %}"
+        "{% if flag %}Y{% elif alt %}N{% else %}Z{% endif %}"
+    )
+    tmpl = _MiniTemplate(tmpl_text)
+    result = tmpl.render({"name": "Ann", "nums": [1, 2], "flag": False, "alt": True})
+    assert result == "Hi Ann![1][2]N"
+
+
+def test_minitemplate_unclosed_for():
+    tmpl = _MiniTemplate("{% for x in items %}{x}")
+    with pytest.raises(ValueError):
+        tmpl.render({"items": [1, 2]})

--- a/llm-signature-framework-v0.2.2/tests/test_tools_validation.py
+++ b/llm-signature-framework-v0.2.2/tests/test_tools_validation.py
@@ -1,0 +1,33 @@
+import asyncio
+import pytest
+from llm_signature_framework.tools import (
+    Tool,
+    ToolRegistry,
+    InputValidationError,
+    OutputValidationError,
+    FatalToolError,
+)
+
+
+@Tool(name="adder")
+def add(a: int, b: int) -> int:
+    return a + b
+
+
+@Tool(name="badadder")
+def bad(a: int, b: int) -> int:
+    return "not an int"
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def test_tool_success_and_validation_errors():
+    assert run(ToolRegistry.call("adder", a=1, b=2)) == 3
+    with pytest.raises(InputValidationError):
+        run(ToolRegistry.call("adder", a="x", b=2))
+    with pytest.raises(OutputValidationError):
+        run(ToolRegistry.call("badadder", a=1, b=2))
+    with pytest.raises(FatalToolError):
+        run(ToolRegistry.call("unknown"))


### PR DESCRIPTION
## Summary
- test templating loops and conditionals
- validate tool input/output and unknown tool handling
- ensure backend selection defaults and overrides
- exercise CLI version output and demo runner

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a876c7db9c832d94a63879e85ee0cb