### PR TITLE
Fix lint warnings causing CI failures

### DIFF
--- a/llm-signature-framework-v0.2.2/src/llm_signature_framework/__init__.py
+++ b/llm-signature-framework-v0.2.2/src/llm_signature_framework/__init__.py
@@ -1,14 +1,14 @@
+from .backends import get_backend, set_backend
 from .templates import LLMFunction, __version__
 from .tools import (
+    ImageBlob,
     Tool,
     ToolRegistry,
-    ImageBlob,
+    call_tool,
     fetch_url,
     list_tools_for_planner,
     list_tools_openai,
-    call_tool,
 )
-from .backends import set_backend, get_backend
 
 __all__ = [
     "LLMFunction",

--- a/llm-signature-framework-v0.2.2/src/llm_signature_framework/cli.py
+++ b/llm-signature-framework-v0.2.2/src/llm_signature_framework/cli.py
@@ -4,12 +4,13 @@ import argparse
 import json
 import os
 import sys
+import textwrap
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
 from .backends import HybridBackend, set_backend
+from .templates import __version__, demo_loop_and_if
 from .tools import ToolRegistry
-from .templates import demo_loop_and_if, __version__
 
 
 class _Studio(BaseHTTPRequestHandler):
@@ -46,24 +47,32 @@ class _Studio(BaseHTTPRequestHandler):
             self.send_error(404)
 
     def _html(self):
-        body = """<!doctype html>
-<title>Prompt Studio (Read-only)</title>
-<style>body{font:14px system-ui;margin:1rem} pre{white-space:pre-wrap}</style>
-<h1>Prompt Studio</h1>
-<p><button onclick="load()">Refresh</button></p>
-<div id="summary"></div>
-<script>
-async function load(){
-  const st = await (await fetch('/state')).json().catch(()=>({}));
-  const runs = await (await fetch('/runs')).json().catch(()=>[]);
-  const total = st.executions?.length||0;
-  const tokens = st.executions?.reduce((a,e)=>a+(e.prompt_tokens||0)+(e.completion_tokens||0),0)||0;
-  document.getElementById('summary').innerHTML = `<p>Total execs: ${total}. Tokens: ${tokens}.</p>`+
-    `<p>Runs: ${runs.map(r=>`+"`"+"<a href='/runs/"+"${r}"+"' target='_blank'>"+"${r}"+"</a>"+"`").join(' | ')}.</p>`;
-}
-load();
-</script>
-"""
+        body = textwrap.dedent(
+            """
+            <!doctype html>
+            <title>Prompt Studio (Read-only)</title>
+            <style>body{font:14px system-ui;margin:1rem} pre{white-space:pre-wrap}</style>
+            <h1>Prompt Studio</h1>
+            <p><button onclick=\"load()\">Refresh</button></p>
+            <div id=\"summary\"></div>
+            <script>
+            async function load(){
+              const st = await (await fetch('/state')).json().catch(()=>({}));
+              const runs = await (await fetch('/runs')).json().catch(()=>[]);
+              const total = st.executions?.length||0;
+              const tokens = st.executions?.reduce(
+                (a,e)=>a+(e.prompt_tokens||0)+(e.completion_tokens||0),0
+              )||0;
+              document.getElementById('summary').innerHTML =
+                `<p>Total execs: ${total}. Tokens: ${tokens}.</p>` +
+                `<p>Runs: ${runs.map(
+                  (r)=>`+"`"+"<a href='/runs/"+"${r}"+"' target='_blank'>"+"${r}"+"</a>"+"`
+                ).join(' | ')}.</p>`;
+            }
+            load();
+            </script>
+            """
+        )
         self._send(200, "text/html; charset=utf-8", body)
 
 

--- a/llm-signature-framework-v0.2.2/src/llm_signature_framework/templates.py
+++ b/llm-signature-framework-v0.2.2/src/llm_signature_framework/templates.py
@@ -6,19 +6,17 @@ import hashlib
 import inspect
 import json
 import os
-import random
 import re
 import textwrap
-import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union, get_type_hints
+from typing import Any, Dict, List, Optional, get_type_hints
 
 from pydantic import BaseModel, TypeAdapter, ValidationError
 
 from .backends import get_backend
 from .state import StateManager
-from .tools import ImageBlob, InputValidationError, OutputValidationError, ExecutionError
+from .tools import ExecutionError, ImageBlob, InputValidationError, OutputValidationError
 
 __version__ = "0.2.2"
 
@@ -214,7 +212,8 @@ class LLMFunction:
                     "temperature": self.temperature,
                 }
                 try:
-                    if "seed" in inspect.signature(backend.run).parameters and self.seed is not None:
+                    sig_params = inspect.signature(backend.run).parameters
+                    if "seed" in sig_params and self.seed is not None:
                         _kwargs["seed"] = self.seed
                 except Exception:
                     pass
@@ -275,8 +274,13 @@ class LLMFunction:
                     if not self.enable_repair or attempt == self.retries:
                         raise OutputValidationError(ve) from ve
                     schema = getattr(Output, "json_schema", lambda: {})()
+                    schema_json = json.dumps(schema, indent=2)
                     repair_instruction = textwrap.dedent(
-                        f"Please return a response that validates against this JSON schema:\n{json.dumps(schema, indent=2)}\nOnly return the JSON object—no prose."
+                        (
+                            "Please return a response that validates against this JSON schema:\n"
+                            f"{schema_json}\n"
+                            "Only return the JSON object—no prose."
+                        )
                     ).strip()
                     if messages is None:
                         messages = [
@@ -339,10 +343,13 @@ def _make_external_prompt_function(
     _fn.__annotations__ = {**params, "return": ret}
     if source_path:
         _fn._prompt_source = source_path
-    from inspect import Signature, Parameter
 
-    parameters = [Parameter(k, kind=Parameter.KEYWORD_ONLY) for k in params.keys()]
-    _fn.__signature__ = Signature(parameters=parameters)  # type: ignore[attr-defined]
+    parameters = [
+        inspect.Parameter(k, kind=inspect.Parameter.KEYWORD_ONLY) for k in params.keys()
+    ]
+    _fn.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
+        parameters=parameters
+    )
     return llm(template=tpl)(_fn)
 
 

--- a/llm-signature-framework-v0.2.2/src/llm_signature_framework/tools.py
+++ b/llm-signature-framework-v0.2.2/src/llm_signature_framework/tools.py
@@ -66,7 +66,13 @@ class ImageBlob(BaseModel):
 
 
 class Tool:
-    def __init__(self, name: Optional[str] = None, desc: Optional[str] = None, retries: int = 2, backoff: float = 0.4):
+    def __init__(
+        self,
+        name: Optional[str] = None,
+        desc: Optional[str] = None,
+        retries: int = 2,
+        backoff: float = 0.4,
+    ):
         self.name, self.desc, self.retries, self.backoff = name, desc, retries, backoff
 
     def __call__(self, func):
@@ -183,7 +189,9 @@ async def call_tool(name: str, arguments: Dict[str, Any]):
 
 @Tool(name="fetch_url", desc="Fetch a URL and return plain text (best-effort)")
 def fetch_url(url: str, timeout: float = 6.0, max_bytes: int = 2_000_000) -> str:
-    import urllib.request, urllib.error, html.parser
+    import html.parser
+    import urllib.error
+    import urllib.request
     from urllib.parse import urlparse
 
     allow = os.getenv("SAFE_FETCH_ALLOWLIST")

--- a/llm-signature-framework-v0.2.2/tests/test_backends.py
+++ b/llm-signature-framework-v0.2.2/tests/test_backends.py
@@ -1,5 +1,4 @@
-import os
-from llm_signature_framework.backends import get_backend, set_backend, MockBackend
+from llm_signature_framework.backends import MockBackend, get_backend, set_backend
 
 
 def test_get_backend_default_and_override(monkeypatch):

--- a/llm-signature-framework-v0.2.2/tests/test_manifest.py
+++ b/llm-signature-framework-v0.2.2/tests/test_manifest.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
+
 from llm_signature_framework import LLMFunction, Tool, ToolRegistry, __version__
+
 
 def test_manifest_and_state(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)

--- a/llm-signature-framework-v0.2.2/tests/test_smoke.py
+++ b/llm-signature-framework-v0.2.2/tests/test_smoke.py
@@ -1,5 +1,6 @@
 from llm_signature_framework import LLMFunction
 
+
 def test_summarize():
     llm = LLMFunction()
     @llm

--- a/llm-signature-framework-v0.2.2/tests/test_templates.py
+++ b/llm-signature-framework-v0.2.2/tests/test_templates.py
@@ -1,4 +1,5 @@
 import pytest
+
 from llm_signature_framework.templates import _MiniTemplate
 
 

--- a/llm-signature-framework-v0.2.2/tests/test_tools_validation.py
+++ b/llm-signature-framework-v0.2.2/tests/test_tools_validation.py
@@ -1,11 +1,13 @@
 import asyncio
+
 import pytest
+
 from llm_signature_framework.tools import (
-    Tool,
-    ToolRegistry,
+    FatalToolError,
     InputValidationError,
     OutputValidationError,
-    FatalToolError,
+    Tool,
+    ToolRegistry,
 )
 
 


### PR DESCRIPTION
## Summary
- reorder imports across the package and tests so Ruff passes on main
- wrap the CLI HTML template and template repair text to respect the 100 character limit
- reformat tool helpers to satisfy Ruff linting while keeping behavior unchanged

## Testing
- ruff check
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fb3ede1b5c832db66918881382f17e