### PR TITLE
test: exercise installed package interfaces

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Lint with Ruff
         run: ruff check .
       - name: Test with pytest
-        run: pytest --cov=src --cov-report=term --cov-fail-under=80
+        run: pytest --cov=llm_signature_framework --cov-report=term --cov-fail-under=80

--- a/llm-signature-framework-v0.2.2/tests/test_backends.py
+++ b/llm-signature-framework-v0.2.2/tests/test_backends.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import urllib.request
 from types import SimpleNamespace
 
 import pytest
@@ -66,8 +67,6 @@ def test_hybrid_backend_posts_payload(monkeypatch):
         captured["headers"] = dict(req.header_items())
         captured["payload"] = req.data
         return FakeResponse(json.dumps({"content": "ok"}).encode())
-
-    import urllib.request
 
     monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
 

--- a/llm-signature-framework-v0.2.2/tests/test_backends.py
+++ b/llm-signature-framework-v0.2.2/tests/test_backends.py
@@ -1,5 +1,17 @@
+import asyncio
+import json
 import os
-from llm_signature_framework.backends import get_backend, set_backend, MockBackend
+from types import SimpleNamespace
+
+import pytest
+
+from llm_signature_framework.backends import (
+    HybridBackend,
+    MockBackend,
+    get_backend,
+    set_backend,
+)
+from llm_signature_framework.tools import FatalToolError
 
 
 def test_get_backend_default_and_override(monkeypatch):
@@ -14,3 +26,64 @@ def test_get_backend_default_and_override(monkeypatch):
     set_backend(None)
     monkeypatch.setenv("LLM_BACKEND", "mock")
     assert isinstance(get_backend(), MockBackend)
+
+
+def test_hybrid_backend_requires_endpoint(monkeypatch):
+    monkeypatch.delenv("HYBRID_BACKEND_URL", raising=False)
+    hb = HybridBackend()
+    with pytest.raises(FatalToolError):
+        asyncio.run(hb.run())
+
+
+def test_hybrid_backend_posts_payload(monkeypatch):
+    monkeypatch.setenv("HYBRID_BACKEND_URL", "https://api.example.com/run")
+    monkeypatch.setenv("HYBRID_API_KEY", "sekret")
+    hb = HybridBackend(headers={"X-Test": "1"})
+
+    captured = {}
+
+    class FakeHeaders(SimpleNamespace):
+        def get_content_charset(self):
+            return "utf-8"
+
+    class FakeResponse:
+        def __init__(self, data: bytes):
+            self._data = data
+            self.headers = FakeHeaders()
+
+        def read(self, *_args, **_kwargs):
+            chunk, self._data = self._data, b""
+            return chunk
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def fake_urlopen(req, timeout=20):  # noqa: N803
+        captured["url"] = req.full_url
+        captured["headers"] = dict(req.header_items())
+        captured["payload"] = req.data
+        return FakeResponse(json.dumps({"content": "ok"}).encode())
+
+    import urllib.request
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    result = asyncio.run(hb.run(messages=[{"role": "user", "content": "hi"}], model="gpt-4o"))
+    assert result == "ok"
+    body = json.loads(captured["payload"].decode())
+    assert body["messages"][0]["content"] == "hi"
+    headers = {k.lower(): v for k, v in captured["headers"].items()}
+    assert headers["authorization"] == "Bearer sekret"
+    assert headers["x-test"] == "1"
+
+
+def test_get_backend_hybrid(monkeypatch):
+    set_backend(None)
+    monkeypatch.setenv("LLM_BACKEND", "hybrid")
+    monkeypatch.setenv("HYBRID_BACKEND_URL", "https://api.example.com/run")
+    backend = get_backend()
+    assert isinstance(backend, HybridBackend)
+    assert backend.endpoint == "https://api.example.com/run"

--- a/llm-signature-framework-v0.2.2/tests/test_cli.py
+++ b/llm-signature-framework-v0.2.2/tests/test_cli.py
@@ -3,6 +3,7 @@ import sys
 import json
 import pytest
 
+import llm_signature_framework.backends as backends
 from llm_signature_framework import cli
 from llm_signature_framework.templates import __version__
 
@@ -58,8 +59,6 @@ def test_cli_run_missing_name(monkeypatch: pytest.MonkeyPatch, capsys: pytest.Ca
 
 
 def test_cli_backend_hybrid(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]):
-    import llm_signature_framework.backends as backends
-
     stub_backend = backends.MockBackend()
 
     monkeypatch.setenv("HYBRID_BACKEND_URL", "https://example.com")

--- a/llm-signature-framework-v0.2.2/tests/test_cli.py
+++ b/llm-signature-framework-v0.2.2/tests/test_cli.py
@@ -1,27 +1,73 @@
-import os
-import subprocess
 import sys
-from pathlib import Path
 
+import json
+import pytest
+
+from llm_signature_framework import cli
 from llm_signature_framework.templates import __version__
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-SRC_PATH = str(PROJECT_ROOT / "src")
+
+def run_cli(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], *args):
+    monkeypatch.setenv("LLM_BACKEND", "mock")
+    monkeypatch.setattr(sys, "argv", ["llm-signature-framework", *args])
+    exit_code = 0
+    try:
+        cli.main()
+    except SystemExit as exc:  # argparse can exit
+        exit_code = exc.code or 0
+    result = capsys.readouterr()
+    return exit_code, result.out, result.err
 
 
-def run_cli(*args):
-    env = os.environ.copy()
-    env.update({"PYTHONPATH": SRC_PATH, "LLM_BACKEND": "mock"})
-    cmd = [sys.executable, "-m", "llm_signature_framework.cli", *args]
-    return subprocess.run(cmd, capture_output=True, text=True, env=env)
+def test_cli_print_version(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]):
+    exit_code, stdout, stderr = run_cli(monkeypatch, capsys, "--print-version")
+    assert exit_code == 0
+    assert stdout.strip() == __version__
+    assert stderr == ""
 
 
-def test_cli_print_version():
-    res = run_cli("--print-version")
-    assert res.stdout.strip() == __version__
+def test_cli_run_demo(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]):
+    exit_code, stdout, stderr = run_cli(
+        monkeypatch,
+        capsys,
+        "run",
+        "--name",
+        "demo_loop_and_if",
+        "--json",
+        '{"things":["x"],"flag": true}',
+    )
+    assert exit_code == 0
+    assert "mock-reply" in stdout
+    assert stderr == ""
 
 
-def test_cli_run_demo():
-    res = run_cli("run", "--name", "demo_loop_and_if", "--json", '{"things":["x"],"flag": true}')
-    assert "mock-reply" in res.stdout
-    assert res.returncode == 0
+def test_cli_list_tools(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]):
+    exit_code, stdout, stderr = run_cli(monkeypatch, capsys, "tools")
+    assert exit_code == 0
+    tools = json.loads(stdout)
+    assert isinstance(tools, list)
+    assert any(t["name"] == "adder" for t in tools)
+    assert stderr == ""
+
+
+def test_cli_run_missing_name(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]):
+    exit_code, stdout, stderr = run_cli(monkeypatch, capsys, "run")
+    assert "--name required" in str(exit_code)
+    assert stdout == ""
+    assert stderr == ""
+
+
+def test_cli_backend_hybrid(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]):
+    import llm_signature_framework.backends as backends
+
+    stub_backend = backends.MockBackend()
+
+    monkeypatch.setenv("HYBRID_BACKEND_URL", "https://example.com")
+    monkeypatch.setattr(backends, "HybridBackend", lambda **_: stub_backend)
+    monkeypatch.setattr(cli, "HybridBackend", lambda **_: stub_backend)
+
+    exit_code, stdout, stderr = run_cli(monkeypatch, capsys, "--backend", "hybrid")
+    assert exit_code == 0
+    assert "mock-reply" in stdout
+    assert stderr == ""
+    backends.set_backend(None)

--- a/llm-signature-framework-v0.2.2/tests/test_llm_function.py
+++ b/llm-signature-framework-v0.2.2/tests/test_llm_function.py
@@ -1,0 +1,89 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+import llm_signature_framework.templates as templates
+from llm_signature_framework.templates import LLMFunction
+
+
+def make_state():
+    store = SimpleNamespace(records=[], manifests=[])
+
+    def log_execution(record):
+        store.records.append(record)
+
+    def write_manifest(manifest):
+        store.manifests.append(manifest)
+
+    store.log_execution = log_execution
+    store.write_manifest = write_manifest
+    return store
+
+
+def test_llm_function_success_and_manifest(monkeypatch):
+    state = make_state()
+    llm = LLMFunction(retries=0, track=True, seed=7)
+    llm.state = state
+
+    class DummyBackend:
+        def __init__(self):
+            self.calls = []
+
+        async def run(self, **kwargs):
+            self.calls.append(kwargs)
+            return {"text": "hello"}
+
+    backend = DummyBackend()
+    monkeypatch.setattr(templates, "get_backend", lambda: backend)
+    monkeypatch.setattr(templates, "_PRICING", {"gpt-4": {"input": 3, "output": 6}})
+
+    @llm
+    def greet(name: str) -> dict:
+        """Hello {name}"""
+        pass
+
+    result = greet("Ada")
+    assert result == {"text": "hello"}
+    assert backend.calls[0]["prompt"].startswith("Hello Ada")
+    assert state.records[0]["seed"] == 7
+    assert state.manifests[0]["function"] == "greet"
+
+    with pytest.raises(templates.InputValidationError):
+        greet(123)  # type: ignore[arg-type]
+
+
+def test_llm_function_repair_flow(monkeypatch):
+    state = make_state()
+    llm = LLMFunction(retries=1, track=True, enable_repair=True)
+    llm.state = state
+
+    class RepairBackend:
+        def __init__(self):
+            self.calls = []
+
+        async def run(self, **kwargs):
+            self.calls.append(kwargs)
+            if len(self.calls) == 1:
+                return "oops"
+            return {"value": 1}
+
+    backend = RepairBackend()
+    monkeypatch.setattr(templates, "get_backend", lambda: backend)
+
+    async def fast_sleep(_):
+        return None
+
+    monkeypatch.setattr(templates.asyncio, "sleep", fast_sleep)
+
+    @llm
+    async def compute(things: list[str]) -> dict:
+        """Process {things}"""
+        pass
+
+    result = asyncio.run(compute(["a"]))
+    assert result == {"value": 1}
+    assert len(backend.calls) == 2
+    repair_message = backend.calls[1]["messages"][-1]["content"]
+    assert "JSON schema" in repair_message
+    assert state.records[-1]["attempt"] == 2

--- a/llm-signature-framework-v0.2.2/tests/test_tools_features.py
+++ b/llm-signature-framework-v0.2.2/tests/test_tools_features.py
@@ -1,5 +1,7 @@
 import asyncio
 import base64
+import urllib.error
+import urllib.request
 
 import pytest
 
@@ -112,16 +114,12 @@ def test_fetch_url_allowlist_and_parsing(monkeypatch):
     def fake_urlopen(req, timeout=6.0):
         return FakeResponse()
 
-    import urllib.request
-
     monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
 
     text = asyncio.run(ToolRegistry.call("fetch_url", url="https://example.com", timeout=0.1, max_bytes=50))
     assert "hello" in text
 
     def raising_urlopen(req, timeout=6.0):
-        import urllib.error
-
         raise urllib.error.URLError("nope")
 
     monkeypatch.setattr(urllib.request, "urlopen", raising_urlopen)

--- a/llm-signature-framework-v0.2.2/tests/test_tools_features.py
+++ b/llm-signature-framework-v0.2.2/tests/test_tools_features.py
@@ -1,7 +1,6 @@
 import asyncio
 import base64
-import urllib.error
-import urllib.request
+from urllib import error, request
 
 import pytest
 
@@ -114,15 +113,15 @@ def test_fetch_url_allowlist_and_parsing(monkeypatch):
     def fake_urlopen(req, timeout=6.0):
         return FakeResponse()
 
-    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(request, "urlopen", fake_urlopen)
 
     text = asyncio.run(ToolRegistry.call("fetch_url", url="https://example.com", timeout=0.1, max_bytes=50))
     assert "hello" in text
 
     def raising_urlopen(req, timeout=6.0):
-        raise urllib.error.URLError("nope")
+        raise error.URLError("nope")
 
-    monkeypatch.setattr(urllib.request, "urlopen", raising_urlopen)
+    monkeypatch.setattr(request, "urlopen", raising_urlopen)
 
     with pytest.raises(ExecutionError):
         asyncio.run(ToolRegistry.call("fetch_url", url="https://example.com", timeout=0.1, max_bytes=50))

--- a/llm-signature-framework-v0.2.2/tests/test_tools_features.py
+++ b/llm-signature-framework-v0.2.2/tests/test_tools_features.py
@@ -1,0 +1,130 @@
+import asyncio
+import base64
+
+import pytest
+
+import llm_signature_framework.tools as tools
+from llm_signature_framework.tools import ExecutionError, FatalToolError, ImageBlob, Tool, ToolRegistry
+
+
+def test_image_blob_modes(tmp_path, monkeypatch):
+    blob = ImageBlob(data=b"hello", mime="image/jpeg")
+    encoded = blob.to_llm_part()
+    assert encoded.startswith("data:image/jpeg;base64,")
+
+    blob_b64 = ImageBlob(mode="b64", data=base64.b64encode(b"hello").decode())
+    assert blob_b64.to_llm_part().endswith("aGVsbG8=")
+
+    file_path = tmp_path / "img.bin"
+    file_path.write_bytes(b"hello")
+    monkeypatch.setattr(tools, "_SAFE_MEDIA_ROOT", str(tmp_path))
+    blob_path = ImageBlob(mode="path", data=file_path, mime="text/plain")
+    assert blob_path.to_llm_part().startswith("data:text/plain;base64,")
+
+    monkeypatch.setattr(tools, "_SAFE_MEDIA_ROOT", str(tmp_path / "other"))
+    with pytest.raises(FatalToolError):
+        ImageBlob(mode="path", data=file_path).to_llm_part()
+
+    monkeypatch.setattr(tools, "_SAFE_MEDIA_ROOT", None)
+    assert ImageBlob(mode="url", data="https://example.com").to_llm_part() == "https://example.com"
+
+
+def test_tool_retry_and_logging(monkeypatch):
+    monkeypatch.setattr(tools.ToolRegistry, "_reg", {}, raising=False)
+
+    events = []
+
+    def record(event):
+        events.append(event)
+
+    monkeypatch.setattr(tools.ToolRegistry._state, "log_execution", record)
+
+    async def fake_sleep(_):
+        return None
+
+    monkeypatch.setattr(tools.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(tools.random, "uniform", lambda a, b: 0.0)
+
+    attempt = {"count": 0}
+
+    @Tool(name="flaky", retries=1, backoff=0.0)
+    async def flaky(x: int) -> int:
+        attempt["count"] += 1
+        if attempt["count"] == 1:
+            raise RuntimeError("boom")
+        return x * 2
+
+    assert asyncio.run(ToolRegistry.call("flaky", x=3)) == 6
+    assert events[0]["ok"] is True
+
+    @Tool(name="always_fail", retries=1, backoff=0.0)
+    async def always_fail(x: int) -> int:
+        raise RuntimeError("bad")
+
+    with pytest.raises(ExecutionError):
+        asyncio.run(ToolRegistry.call("always_fail", x=1))
+
+    assert events[-1]["ok"] is False
+    assert "bad" in events[-1]["error"]
+
+
+def test_list_tools_openai_format(monkeypatch):
+    monkeypatch.setattr(tools.ToolRegistry, "_reg", {}, raising=False)
+
+    @Tool(name="hello", desc="Say hello")
+    def hello(name: str) -> str:
+        return f"hi {name}"
+
+    tools_info = tools.list_tools_openai()
+    assert tools_info[0]["function"]["name"] == "hello"
+    assert "parameters" in tools_info[0]["function"]
+
+
+def test_fetch_url_allowlist_and_parsing(monkeypatch):
+    monkeypatch.setenv("SAFE_FETCH_ALLOWLIST", "example.com")
+
+    with pytest.raises(FatalToolError):
+        asyncio.run(ToolRegistry.call("fetch_url", url="https://other.com", timeout=0.1, max_bytes=10))
+
+    monkeypatch.setenv("SAFE_FETCH_ALLOWLIST", "")
+
+    class FakeHeaders:
+        def get_content_charset(self):
+            return "utf-8"
+
+    class FakeResponse:
+        def __init__(self):
+            self.headers = FakeHeaders()
+            self._reads = [
+                b"<html><body>hello <b>world</b></body></html>",
+                b"",
+            ]
+
+        def read(self, *_args, **_kwargs):
+            return self._reads.pop(0)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def fake_urlopen(req, timeout=6.0):
+        return FakeResponse()
+
+    import urllib.request
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    text = asyncio.run(ToolRegistry.call("fetch_url", url="https://example.com", timeout=0.1, max_bytes=50))
+    assert "hello" in text
+
+    def raising_urlopen(req, timeout=6.0):
+        import urllib.error
+
+        raise urllib.error.URLError("nope")
+
+    monkeypatch.setattr(urllib.request, "urlopen", raising_urlopen)
+
+    with pytest.raises(ExecutionError):
+        asyncio.run(ToolRegistry.call("fetch_url", url="https://example.com", timeout=0.1, max_bytes=50))


### PR DESCRIPTION
## Summary
- exercise the CLI in-process to cover multiple commands against the installed package
- add regression tests for hybrid backend selection and payload handling
- extend tool and LLMFunction tests to validate retries, repair flows, and manifest logging

## Testing
- pytest --cov=llm_signature_framework --cov-report=term --cov-fail-under=80


------
https://chatgpt.com/codex/tasks/task_e_68fbbf807084832db3c7b37b1a0f5d5d